### PR TITLE
Display CfA statistics to managers and reviewers

### DIFF
--- a/indico_jacow/blueprint.py
+++ b/indico_jacow/blueprint.py
@@ -7,13 +7,16 @@
 
 from indico.core.plugins import IndicoPluginBlueprint
 
-from indico_jacow.controllers import RHAbstractsExportCSV, RHAbstractsExportExcel, RHAbstractsStats
+from indico_jacow.controllers import (RHAbstractsExportCSV, RHAbstractsExportExcel, RHAbstractsStats,
+                                      RHDisplayAbstractsStatistics)
 
 
 blueprint = IndicoPluginBlueprint('jacow', __name__, url_prefix='/event/<int:event_id>')
 
 
 # Statistics
+blueprint.add_url_rule('/abstracts/reviewing/statistics', 'reviewer_stats',
+                       RHDisplayAbstractsStatistics, methods=('GET',))
 blueprint.add_url_rule('/manage/abstracts/statistics', 'abstracts_stats',
                        RHAbstractsStats, methods=('GET',))
 

--- a/indico_jacow/blueprint.py
+++ b/indico_jacow/blueprint.py
@@ -7,11 +7,17 @@
 
 from indico.core.plugins import IndicoPluginBlueprint
 
-from indico_jacow.controllers import RHAbstractsExportCSV, RHAbstractsExportExcel
+from indico_jacow.controllers import RHAbstractsExportCSV, RHAbstractsExportExcel, RHAbstractsStats
 
 
 blueprint = IndicoPluginBlueprint('jacow', __name__, url_prefix='/event/<int:event_id>')
 
+
+# Statistics
+blueprint.add_url_rule('/manage/abstracts/statistics', 'abstracts_stats',
+                       RHAbstractsStats, methods=('GET',))
+
+# Custom exports
 blueprint.add_url_rule('/manage/abstracts/abstracts_custom.csv', 'abstracts_csv_export_custom',
                        RHAbstractsExportCSV, methods=('POST',))
 blueprint.add_url_rule('/manage/abstracts/abstracts_custom.xlsx', 'abstracts_xlsx_export_custom',

--- a/indico_jacow/blueprint.py
+++ b/indico_jacow/blueprint.py
@@ -15,10 +15,8 @@ blueprint = IndicoPluginBlueprint('jacow', __name__, url_prefix='/event/<int:eve
 
 
 # Statistics
-blueprint.add_url_rule('/abstracts/reviewing/statistics', 'reviewer_stats',
-                       RHDisplayAbstractsStatistics, methods=('GET',))
-blueprint.add_url_rule('/manage/abstracts/statistics', 'abstracts_stats',
-                       RHAbstractsStats, methods=('GET',))
+blueprint.add_url_rule('/abstracts/reviewing/statistics', 'reviewer_stats', RHDisplayAbstractsStatistics)
+blueprint.add_url_rule('/manage/abstracts/statistics', 'abstracts_stats', RHAbstractsStats)
 
 # Custom exports
 blueprint.add_url_rule('/manage/abstracts/abstracts_custom.csv', 'abstracts_csv_export_custom',

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -11,6 +11,8 @@ from wtforms.fields import BooleanField
 
 from indico.core import signals
 from indico.core.plugins import IndicoPlugin, url_for_plugin
+from indico.modules.events.abstracts.util import has_user_tracks
+from indico.modules.events.layout.util import MenuEntryData
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.widgets import SwitchWidget
@@ -39,10 +41,22 @@ class JACOWPlugin(IndicoPlugin):
     def init(self):
         super().init()
         self.template_hook('abstract-list-options', self.inject_export_button)
+        self.connect(signals.event.sidemenu, self.extend_event_menu)
         self.connect(signals.menu.items, self.add_sidemenu_item, sender='event-management-sidemenu')
 
     def inject_export_button(self, event=None):
         return render_plugin_template('export_button.html', event=event)
+
+    def extend_event_menu(self, sender, **kwargs):
+        def _statistics_visible(event):
+            if not session.user or not event.has_feature('abstracts'):
+                return False
+            return any(track.can_review_abstracts(session.user) for track in event.tracks)
+            return has_user_tracks(event, session.user)
+
+        return MenuEntryData(title=_('My Statistics'), name='abstract_reviewing_stats',
+                             endpoint='jacow.reviewer_stats', position=1, parent='call_for_abstracts',
+                             visible=_statistics_visible)
 
     def add_sidemenu_item(self, sender, event, **kwargs):
         if not event.can_manage(session.user) or not event.has_feature('abstracts'):

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -11,7 +11,6 @@ from wtforms.fields import BooleanField
 
 from indico.core import signals
 from indico.core.plugins import IndicoPlugin, url_for_plugin
-from indico.modules.events.abstracts.util import has_user_tracks
 from indico.modules.events.layout.util import MenuEntryData
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
@@ -52,7 +51,6 @@ class JACOWPlugin(IndicoPlugin):
             if not session.user or not event.has_feature('abstracts'):
                 return False
             return any(track.can_review_abstracts(session.user) for track in event.tracks)
-            return has_user_tracks(event, session.user)
 
         return MenuEntryData(title=_('My Statistics'), name='abstract_reviewing_stats',
                              endpoint='jacow.reviewer_stats', position=1, parent='call_for_abstracts',

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -5,13 +5,16 @@
 # them and/or modify them under the terms of the MIT License; see
 # the LICENSE file for more details.
 
+from flask import session
 from flask_pluginengine import render_plugin_template
 from wtforms.fields import BooleanField
 
-from indico.core.plugins import IndicoPlugin
+from indico.core import signals
+from indico.core.plugins import IndicoPlugin, url_for_plugin
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.widgets import SwitchWidget
+from indico.web.menu import SideMenuItem
 
 from indico_jacow.blueprint import blueprint
 
@@ -36,9 +39,16 @@ class JACOWPlugin(IndicoPlugin):
     def init(self):
         super().init()
         self.template_hook('abstract-list-options', self.inject_export_button)
+        self.connect(signals.menu.items, self.add_sidemenu_item, sender='event-management-sidemenu')
 
     def inject_export_button(self, event=None):
         return render_plugin_template('export_button.html', event=event)
+
+    def add_sidemenu_item(self, sender, event, **kwargs):
+        if not event.can_manage(session.user) or not event.has_feature('abstracts'):
+            return
+        return SideMenuItem('abstracts_stats', _('CfA Statistics'),
+                            url_for_plugin('jacow.abstracts_stats', event), section='reports')
 
     def get_blueprints(self):
         return blueprint

--- a/indico_jacow/templates/abstracts_stats.html
+++ b/indico_jacow/templates/abstracts_stats.html
@@ -32,7 +32,7 @@
                 {% for item in list_items -%}
                     {% if item.is_track_group %}
                         {% for track in item.tracks %}
-                            <th class="i-table">{{ track.code if track.code else track.title }}</th>
+                            <th class="i-table">{{ track.code or track.title }}</th>
                         {% endfor %}
                         <th class="i-table">{% trans %}Subtotal{% endtrans %}</th>
                     {% endif %}
@@ -49,11 +49,11 @@
                     {% for item in list_items -%}
                         {% if item.is_track_group %}
                             {% for track in item.tracks -%}
-                                <td class="i-table">{{ reviewer_counts[track] }}</td>
+                                <td class="i-table">{{ reviewer_counts[track] or 0 }}</td>
                             {%- endfor %}
-                            <td class="i-table">{{ reviewer_counts[item] }}</td>
+                            <td class="i-table">{{ reviewer_counts[item] or 0 }}</td>
                         {% else %}
-                            <td class="i-table">{{ reviewer_counts[item] }}</td>
+                            <td class="i-table">{{ reviewer_counts[item] or 0 }}</td>
                         {% endif %}
                     {%- endfor %}
                     <td class="i-table">{{ reviewer_counts.total }}</td>

--- a/indico_jacow/templates/abstracts_stats.html
+++ b/indico_jacow/templates/abstracts_stats.html
@@ -1,0 +1,77 @@
+{% extends 'events/management/base.html' %}
+
+{% from 'events/tracks/_track_list.html' import render_list %}
+
+{% block title %}
+    {%- trans %}Call for Abstracts Statistics{% endtrans -%}
+{% endblock %}
+
+{% block description %}
+    {%- trans -%}
+        Statistics regarding the Call for Abstracts review and judgement process.
+    {%- endtrans -%}
+{% endblock %}
+
+{% macro _render_stats_table(counts) %}
+    <table class="i-table-widget tablesorter">
+        <thead>
+            <tr class="i-table">
+                <th class="i-table" rowspan="2">{% trans %}Reviewer{% endtrans %}</th>
+                {% for item in list_items -%}
+                    {% if item.is_track_group %}
+                        <th class="i-table" colspan="{{ item.tracks|length + 1 }}">{{ item.code if item.code else item.title }}</th>
+                    {% else %}
+                        <th class="i-table" rowspan="2">{{ item.code if item.code else item.title }}</th>
+                    {% endif %}
+                {%- else -%}
+                    <th class="i-table" rowspan="2">{% trans %}Number of reviews{% endtrans %}</th>
+                {%- endfor %}
+                <th class="i-table" rowspan="2">{% trans %}Total{% endtrans %}</th>
+            </tr>
+            <tr class="i-table">
+                {% for item in list_items -%}
+                    {% if item.is_track_group %}
+                        {% for track in item.tracks %}
+                            <th class="i-table">{{ track.code if track.code else track.title }}</th>
+                        {% endfor %}
+                        <th class="i-table">{% trans %}Subtotal{% endtrans %}</th>
+                    {% endif %}
+                {%- endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for reviewer in reviewers -%}
+                {% set reviewer_counts = counts[reviewer] %}
+                <tr class="i-table">
+                    <td class="i-table name-column">
+                        {{ reviewer.full_name }}
+                    </td>
+                    {% for item in list_items -%}
+                        {% if item.is_track_group %}
+                            {% for track in item.tracks -%}
+                                <td class="i-table">{{ reviewer_counts[track] }}</td>
+                            {%- endfor %}
+                            <td class="i-table">{{ reviewer_counts[item] }}</td>
+                        {% else %}
+                            <td class="i-table">{{ reviewer_counts[item] }}</td>
+                        {% endif %}
+                    {%- endfor %}
+                    <td class="i-table">{{ reviewer_counts.total }}</td>
+                </tr>
+            {%- endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
+{% block content %}
+    <h3>{% trans %}Number of reviews per track{% endtrans %}</h3>
+    {% if reviewers and list_items %}
+        {{ _render_stats_table(review_counts) }}
+    {% else %}
+        {%- trans %}No reviews have been made yet.{% endtrans -%}
+    {% endif %}
+    {% for question in questions %}
+        <h3>{% trans title=question.title %}Positive answers to question "{{ title }}"{% endtrans %}</h3>
+        {{ _render_stats_table(question_counts[question]) }}
+    {% endfor %}
+{% endblock %}

--- a/indico_jacow/templates/abstracts_stats.html
+++ b/indico_jacow/templates/abstracts_stats.html
@@ -8,7 +8,7 @@
 
 {% block description %}
     {%- trans -%}
-        Statistics regarding the Call for Abstracts review and judgement process.
+        Statistics regarding the Call for Abstracts review and judgment process.
     {%- endtrans -%}
 {% endblock %}
 

--- a/indico_jacow/templates/reviewer_stats.html
+++ b/indico_jacow/templates/reviewer_stats.html
@@ -24,7 +24,7 @@
         <div class="label i-tag"
              title="{% trans %}Number of positive answers to the question{% endtrans %}">
             {{ question.title }}
-            <span class="badge">{{ question_counts[question][track] }}</span>
+            <span class="badge">{{ question_counts[question][track] or 0 }}</span>
         </div>
     {% endfor %}
 {% endmacro %}

--- a/indico_jacow/templates/reviewer_stats.html
+++ b/indico_jacow/templates/reviewer_stats.html
@@ -1,0 +1,80 @@
+{% extends 'events/display/conference/base.html' %}
+
+{% block title %}
+    {{- page_title -}}
+{% endblock %}
+
+{% block description %}
+    {%- trans %}The reviewing statistics area shows statistics for the tracks for which you are a reviewer.{% endtrans -%}
+{% endblock %}
+
+{% macro _render_labels(track) %}
+    {% set count = abstract_count[track] %}
+    <div class="label i-tag"
+         title="{% trans %}Number of abstracts you have reviewed{% endtrans %}">
+        {%- trans %}Reviewed{% endtrans -%}
+        <span class="badge">{{ count.reviewed }}</span>
+    </div>
+    <div class="label i-tag"
+         title="{% trans %}Number of unreviewed abstracts{% endtrans %}">
+        {%- trans %}Unreviewed{% endtrans -%}
+        <span class="badge">{{ count.unreviewed }}</span>
+    </div>
+    {% for question in question_counts %}
+        <div class="label i-tag"
+             title="{% trans %}Number of positive answers to the question{% endtrans %}">
+            {{ question.title }}
+            <span class="badge">{{ question_counts[question][track] }}</span>
+        </div>
+    {% endfor %}
+{% endmacro %}
+
+{% macro _render_track(track) %}
+    <div class="title">
+        <a href="{{ url_for('abstracts.display_reviewable_track_abstracts', track) }}">
+            {{- track.title -}}
+        </a>
+    </div>
+    {{ _render_labels(track) }}
+{% endmacro %}
+
+{% block content %}
+    <div class="track-review-list">
+        {% if not list_items %}
+            <div class="info-message-box">
+                <span class="icon"></span>
+                <div class="message-text">
+                    {%- trans %}There are currently no tracks for which you are a reviewer or convener.{% endtrans -%}
+                </div>
+            </div>
+        {% else %}
+            <ul>
+                {% for item in list_items %}
+                    <div class="track-review-row">
+                        <li>
+                            {% if item.is_track_group %}
+                                <div class="title">
+                                    {{- item.title -}}
+                                </div>
+                                {{ _render_labels(item) }}
+                                <ul>
+                                    {% for track in item.tracks %}
+                                        {% if track.can_review_abstracts(session.user) %}
+                                            <div class="track-review-row">
+                                                <li>
+                                                    {{ _render_track(track) }}
+                                                </li>
+                                            </div>
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                {{ _render_track(item) }}
+                            {% endif %}
+                        </li>
+                    </div>
+                {%  endfor %}
+            </ul>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/indico_jacow/views.py
+++ b/indico_jacow/views.py
@@ -1,0 +1,13 @@
+# This file is part of the JACoW plugin.
+# Copyright (C) 2021 - 2023 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+from indico.core.plugins import WPJinjaMixinPlugin
+from indico.modules.events.management.views import WPEventManagement
+
+
+class WPAbstractsStats(WPJinjaMixinPlugin, WPEventManagement):
+    sidemenu_option = 'abstracts_stats'

--- a/indico_jacow/views.py
+++ b/indico_jacow/views.py
@@ -6,7 +6,13 @@
 # the LICENSE file for more details.
 
 from indico.core.plugins import WPJinjaMixinPlugin
+from indico.modules.events.abstracts.views import WPDisplayAbstracts
 from indico.modules.events.management.views import WPEventManagement
+
+
+class WPDisplayAbstractsStatistics(WPJinjaMixinPlugin, WPDisplayAbstracts):
+    menu_entry_name = 'abstract_reviewing_stats'
+    menu_entry_plugin = 'jacow'
 
 
 class WPAbstractsStats(WPJinjaMixinPlugin, WPEventManagement):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-jacow
-version = 3.2.2
+version = 3.2.3
 description = Indico plugin with JACoW-specific functionality
 url = https://gitlab.cern.ch/indico/indico-plugin-jacow
 license = MIT


### PR DESCRIPTION
This PR adds two pages with statistics about abstract reviewing - one for each reviewer, and one for managers with global stats about all reviewers.

The statistics shown are the number of abstracts reviewed, and the positive answers to Yes/No questions, per track and per track group.

For reviewers:
<img width="891" alt="image" src="https://user-images.githubusercontent.com/27357203/227485622-ce0e4a99-4a72-45f6-8c9f-9d00a7c614d6.png">

For managers:
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/27357203/227486151-aa5569e3-d718-48fd-9003-e8d2152ab947.png">
