### PR TITLE
Add "Abstracts in Tracks" statistics

### DIFF
--- a/indico_jacow/controllers.py
+++ b/indico_jacow/controllers.py
@@ -101,9 +101,21 @@ class RHAbstractsStats(RHManageEventBase):
             question_counts[question] = {}
             for user in reviewers:
                 question_counts[question][user] = _get_question_counts(question, user)
+
+        abstracts_in_tracks_attrs = {
+            'submitted_for': lambda t: len(t.abstracts_submitted),
+            'moved_to': lambda t: len(t.abstracts_reviewed - t.abstracts_submitted),
+            'final_proposals': lambda t: len(t.abstracts_reviewed),
+        }
+        abstracts_in_tracks = {track: {k: v(track) for k, v in abstracts_in_tracks_attrs.items()}
+                               for track in self.event.tracks}
+        abstracts_in_tracks.update({group: {k: sum(abstracts_in_tracks[track][k] for track in group.tracks)
+                                            for k in abstracts_in_tracks_attrs}
+                                    for group in self.event.track_groups})
         return WPAbstractsStats.render_template('abstracts_stats.html', self.event, reviewers=reviewers,
                                                 list_items=list_items, review_counts=review_counts,
-                                                questions=questions, question_counts=question_counts)
+                                                questions=questions, question_counts=question_counts,
+                                                abstracts_in_tracks=abstracts_in_tracks)
 
 
 def _append_affiliation_data_fields(headers, rows, items):

--- a/indico_jacow/templates/abstracts_stats.html
+++ b/indico_jacow/templates/abstracts_stats.html
@@ -19,9 +19,9 @@
                 <th class="i-table" rowspan="2">{% trans %}Reviewer{% endtrans %}</th>
                 {% for item in list_items -%}
                     {% if item.is_track_group %}
-                        <th class="i-table" colspan="{{ item.tracks|length + 1 }}">{{ item.code if item.code else item.title }}</th>
+                        <th class="i-table" colspan="{{ item.tracks|length + 1 }}">{{ item.code or item.title }}</th>
                     {% else %}
-                        <th class="i-table" rowspan="2">{{ item.code if item.code else item.title }}</th>
+                        <th class="i-table" rowspan="2">{{ item.code or item.title }}</th>
                     {% endif %}
                 {%- else -%}
                     <th class="i-table" rowspan="2">{% trans %}Number of reviews{% endtrans %}</th>
@@ -64,6 +64,7 @@
 {% endmacro %}
 
 {% block content %}
+    <h2>{% trans %}Summary of reviews{% endtrans %}</h2>
     <h3>{% trans %}Number of reviews per track{% endtrans %}</h3>
     {% if reviewers and list_items %}
         {{ _render_stats_table(review_counts) }}
@@ -74,4 +75,48 @@
         <h3>{% trans title=question.title %}Positive answers to question "{{ title }}"{% endtrans %}</h3>
         {{ _render_stats_table(question_counts[question]) }}
     {% endfor %}
+
+    <h2>{% trans %}Abstracts in tracks{% endtrans %}</h2>
+    {% if list_items %}
+        <table class="i-table-widget tablesorter">
+            <thead>
+                <tr class="i-table">
+                    <th class="i-table" colspan="2">{% trans %}Track{% endtrans %}</th>
+                    <th class="i-table">{% trans %}Originally submitted for{% endtrans %}</th>
+                    <th class="i-table">{% trans %}Moved into{% endtrans %}</th>
+                    <th class="i-table">{% trans %}Final proposals{% endtrans %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in list_items -%}
+                    {% if item.is_track_group %}
+                        <tr class="i-table">
+                            <td class="i-table" rowspan="{{ item.tracks|length + 1 }}">{{ item.code or item.title }}</td>
+                            <td class="i-table">{% trans %}Subtotal{% endtrans %}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].submitted_for }}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].moved_to }}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].final_proposals }}</td>
+                        </tr>
+                        {% for track in item.tracks -%}
+                            <tr class="i-table">
+                                <td class="i-table">{{ track.code or track.title }}</td>
+                                <td class="i-table">{{ abstracts_in_tracks[track].submitted_for }}</td>
+                                <td class="i-table">{{ abstracts_in_tracks[track].moved_to }}</td>
+                                <td class="i-table">{{ abstracts_in_tracks[track].final_proposals }}</td>
+                            </tr>
+                        {%- endfor %}
+                    {% else %}
+                        <tr class="i-table">
+                            <td class="i-table" colspan="2">{{ item.code or item.title }}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].submitted_for }}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].moved_to }}</td>
+                            <td class="i-table">{{ abstracts_in_tracks[item].final_proposals }}</td>
+                        </tr>
+                    {% endif %}
+                {%- endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        {%- trans %}No tracks have been created yet.{% endtrans -%}
+    {% endif %}
 {% endblock %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-jacow
-version = 3.2.4
+version = 3.2.5
 description = Indico plugin with JACoW-specific functionality
 url = https://gitlab.cern.ch/indico/indico-plugin-jacow
 license = MIT


### PR DESCRIPTION
This PR adds an "Abstracts in Tracks" section to the "CfA Statistics" page. The table shows the number of abstracts originally submitted to each track (`Track.abstracts_submitted`), the abstracts moved into each track (`Track.abstracts_reviewed - Track.abstracts_submitted`), and the final proposal count (`Track.abstracts_reviewed`).

<img width="1379" alt="image" src="https://github.com/indico/indico-plugin-jacow/assets/27357203/c4807ba6-f414-495a-9c6b-367dfc6b7148">
