### PR TITLE
Make fields required in "enter person" dialog

### DIFF
--- a/indico_jacow/client/MultipleAffiliationsSelector.jsx
+++ b/indico_jacow/client/MultipleAffiliationsSelector.jsx
@@ -228,14 +228,12 @@ export function MultipleAffiliationsButton({person, onEdit, disabled, extraParam
         <IconGroup size="large">
           <Icon
             name="building"
-            color={
-              person.jacowAffiliationsIds && person.jacowAffiliationsIds.length ? 'blue' : 'grey'
-            }
+            color={person.jacowAffiliationsIds?.length ? 'blue' : 'grey'}
             onClick={() => onEdit('jacow_affiliations')}
             disabled={disabled || !person.email}
             link={!(disabled || !person.email)}
           />
-          {!person.jacowAffiliationsIds && (
+          {!person.jacowAffiliationsIds?.length && (
             <Icon
               name="exclamation circle"
               title={Translate.string('No affiliations added')}

--- a/indico_jacow/client/MultipleAffiliationsSelector.jsx
+++ b/indico_jacow/client/MultipleAffiliationsSelector.jsx
@@ -11,7 +11,17 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
-import {Dropdown, Header, Icon, IconGroup, List, Popup, Ref, Segment} from 'semantic-ui-react';
+import {
+  Dropdown,
+  Header,
+  Icon,
+  IconGroup,
+  List,
+  Popup,
+  Ref,
+  Segment,
+  Message,
+} from 'semantic-ui-react';
 
 import {FinalField} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
@@ -19,6 +29,7 @@ import {SortableWrapper, useSortableItem} from 'indico/react/sortable';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import {makeAsyncDebounce} from 'indico/utils/debounce';
+import {Param} from 'indico/react/i18n';
 
 import {Translate} from './i18n';
 
@@ -198,6 +209,16 @@ export default function MultipleAffiliationsSelector({
           })) || [],
       }}
     >
+      <Message info>
+        <Icon name="info" />
+        <Translate>
+          Please contact{' '}
+          <Param name="email" wrapper={<a href="mailto:indico-support@jacow.org" />}>
+            indico-support@jacow.org
+          </Param>{' '}
+          if your affiliation is not available in the list.
+        </Translate>
+      </Message>
       <FinalField
         name="affiliationsData"
         component={MultipleAffiliationsField}

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -63,6 +63,7 @@ class JACOWPlugin(IndicoPlugin):
         self.connect(signals.core.form_validated, self._person_lists_form_validated)
         self.connect(signals.core.form_validated, self._submission_form_validated)
         self.connect(signals.event.person_link_field_extra_params, self._person_link_field_extra_params)
+        self.connect(signals.event.person_required_fields, self._person_required_fields)
         self.connect(signals.event.abstract_accepted, self._abstract_accepted)
         self.connect(signals.event.sidemenu, self._extend_event_menu)
         self.connect(signals.menu.items, self._add_sidemenu_item, sender='event-management-sidemenu')
@@ -147,6 +148,13 @@ class JACOWPlugin(IndicoPlugin):
             self.event_settings.get(field.event, 'multiple_affiliations')
         ):
             return {'disable_affiliations': True, 'jacow_affiliations': True}
+
+    def _person_required_fields(self, form, **kwargs):
+        if (
+            isinstance(form, (AbstractForm, ContributionForm)) and
+            self.event_settings.get(form.event, 'multiple_affiliations')
+        ):
+            return ['first_name', 'last_name', 'email']
 
     def _abstract_accepted(self, abstract, contribution, **kwargs):
         for contrib_person in contribution.person_links:

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -128,14 +128,17 @@ class JACOWPlugin(IndicoPlugin):
         if not self.event_settings.get(form.event, 'multiple_affiliations'):
             return
         if isinstance(form, AbstractForm):
-            person_links = form.person_links.data
+            person_links = form.person_links
             affiliations_cls = AbstractAffiliation
         else:
-            person_links = form.person_link_data.data
+            person_links = form.person_link_data
             affiliations_cls = ContributionAffiliation
         affiliations_ids = g.pop('jacow_affiliations_ids', {})
-        for person_link in person_links:
+        for person_link in person_links.data:
             person_affiliations = affiliations_ids.get(person_link.person.email, [])
+            if not person_affiliations:
+                person_links.errors.append(_('Affiliations are required for everyone'))
+                return False
             person_link.jacow_affiliations = []
             db.session.flush()
             person_link.jacow_affiliations = [affiliations_cls(affiliation_id=id, display_order=i)
@@ -152,9 +155,9 @@ class JACOWPlugin(IndicoPlugin):
     def _person_required_fields(self, form, **kwargs):
         if (
             isinstance(form, (AbstractForm, ContributionForm)) and
-            self.event_settings.get(form.event, 'multiple_affiliations')
+            persons_settings.get(form.event, 'enforce_user_search')
         ):
-            return ['first_name', 'last_name', 'email']
+            return ['first_name', 'email']
 
     def _abstract_accepted(self, abstract, contribution, **kwargs):
         for contrib_person in contribution.person_links:
@@ -181,9 +184,6 @@ class JACOWPlugin(IndicoPlugin):
                             url_for_plugin('jacow.abstracts_stats', event), section='reports')
 
     def _person_link_schema_pre_load(self, sender, data, **kwargs):
-        if not data.get('email'):
-            # XXX: we do not support affiliations for persons without email for now
-            return
         if hasattr(g, 'jacow_affiliations_ids'):
             g.jacow_affiliations_ids[data['email']] = data.get('jacow_affiliations_ids', [])
         else:

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -153,10 +153,7 @@ class JACOWPlugin(IndicoPlugin):
             return {'disable_affiliations': True, 'jacow_affiliations': True}
 
     def _person_required_fields(self, form, **kwargs):
-        if (
-            isinstance(form, (AbstractForm, ContributionForm)) and
-            persons_settings.get(form.event, 'enforce_user_search')
-        ):
+        if isinstance(form, (AbstractForm, ContributionForm)):
             return ['first_name', 'email']
 
     def _abstract_accepted(self, abstract, contribution, **kwargs):


### PR DESCRIPTION
This PR makes the fields `first_name`,  `email` and affiliations required when "multiple affiliations" is enabled. Depends on https://github.com/indico/indico/pull/6689