### PR TITLE
Allow creating new affiliations after searching

### DIFF
--- a/indico_jacow/blueprint.py
+++ b/indico_jacow/blueprint.py
@@ -8,8 +8,8 @@
 from indico.core.plugins import IndicoPluginBlueprint
 
 from indico_jacow.controllers import (RHAbstractsExportCSV, RHAbstractsExportExcel, RHAbstractsStats,
-                                      RHContributionsExportCSV, RHContributionsExportExcel,
-                                      RHDisplayAbstractsStatistics, RHPeerReviewCSVImport)
+                                      RHContributionsExportCSV, RHContributionsExportExcel, RHCountries,
+                                      RHCreateAffiliation, RHDisplayAbstractsStatistics, RHPeerReviewCSVImport)
 
 
 blueprint = IndicoPluginBlueprint('jacow', __name__, url_prefix='/event/<int:event_id>')
@@ -32,3 +32,6 @@ blueprint.add_url_rule('/manage/contributions/contributions_custom.xlsx', 'contr
 # Peer reviewing CSV import
 blueprint.add_url_rule('/manage/api/papers/jacow-csv-import', 'peer_review_csv_import', RHPeerReviewCSVImport,
                        methods=('POST',))
+
+blueprint.add_url_rule('!/api/jacow/countries', 'countries', RHCountries)
+blueprint.add_url_rule('!/api/jacow/affiliation', 'create_affiliation', RHCreateAffiliation, methods=('POST',))


### PR DESCRIPTION
Letting people choose ONLY stuff from ROR turned out to be a bad idea. Like this they can create new predefined affiliations, which can be later moderated/corrected (not part of this PR).

---

Before searching:

![image](https://github.com/user-attachments/assets/bf5844eb-f2c0-427b-a621-13b0b71c5253)

After searching:

![image](https://github.com/user-attachments/assets/a6947095-53b9-4104-926a-2548eb844e57)

When adding something new:

![image](https://github.com/user-attachments/assets/344311e0-6778-4db0-ad57-b3765638747b)

Afterwards it gets automatically added to the list of affiliations:

![image](https://github.com/user-attachments/assets/abdef258-52de-43e0-bad5-80f785c255f3)
