### PR TITLE
ci: Use astral-sh/setup-uv to install uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  PYTHON_VERSION: '3.12.7'
+  PYTHON_VERSION: '3.12.11'
 
 on:
   push:
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Pick Indico core repo
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,30 +43,18 @@ jobs:
 
       - name: Create virtualenv
         run: |
-          python3.12 -m venv .venv
+          uv venv --python ${{ env.PYTHON_VERSION }} --seed .venv
           source .venv/bin/activate
-          pip install -U pip setuptools wheel
 
       - name: Activate virtualenv for later steps
         run: |
           echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
           echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache pip
-        id: cache-pip
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip|${{ runner.os }}|3.12|${{ hashFiles('**/pyproject.toml') }}
-
       - name: Install Indico
         run: |
-          pip install Babel
-          pip install "indico[dev] @ git+https://github.com/${INDICO_REPO}.git@${INDICO_BRANCH}"
+          uv pip install babel
+          uv pip install "indico[dev] @ git+https://github.com/${INDICO_REPO}.git@${INDICO_BRANCH}"
 
       - name: Archive environment
         run: tar cf /tmp/env.tar .venv
@@ -146,6 +137,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Download environment
         uses: actions/download-artifact@v4
         with:
@@ -163,7 +157,7 @@ jobs:
       - name: Install plugin
         run: |
           cd "${GITHUB_WORKSPACE}"
-          pip install -e .
+          uv pip install -e .
 
       - name: Install redis
         run: sudo apt-get install redis-server


### PR DESCRIPTION
Also use `uv` in all CI jobs where we still used classic pip