### PR TITLE
Fix affiliation text on edit multiple affiliations

### DIFF
--- a/indico_jacow/controllers_test.py
+++ b/indico_jacow/controllers_test.py
@@ -6,13 +6,69 @@
 # the LICENSE file for more details.
 
 import pytest
+from flask import g
+from marshmallow import EXCLUDE
 
 from indico.modules.events.abstracts.lists import AbstractListGeneratorManagement
 from indico.modules.events.abstracts.models.abstracts import Abstract
 from indico.modules.events.abstracts.models.review_questions import AbstractReviewQuestion
 from indico.modules.events.abstracts.models.review_ratings import AbstractReviewRating
 from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractReview
+from indico.modules.events.contributions.models.persons import ContributionPersonLink
 from indico.modules.events.tracks import Track
+from indico.modules.users.models.affiliations import Affiliation
+
+from indico_jacow.models.affiliations import ContributionAffiliation
+
+
+def test_person_link_schema_pre_load_ignores_core_affiliation_for_jacow_affiliations(db, app):
+    from indico.modules.events.persons.schemas import PersonLinkSchema
+
+    from indico_jacow.plugin import JACOWPlugin
+
+    affiliations = [
+        Affiliation(name='Affiliation One'),
+        Affiliation(name='Affiliation Two'),
+        Affiliation(name='Affiliation Three'),
+    ]
+    db.session.add_all(affiliations)
+    db.session.flush()
+    affiliation_text = '; '.join(affiliation.name for affiliation in affiliations)
+    data = {
+        'first_name': 'Ada',
+        'last_name': 'Lovelace',
+        'email': 'ada@example.com',
+        'affiliation': affiliation_text,
+        'affiliation_id': affiliations[0].id,
+        'jacow_affiliations_ids': [affiliation.id for affiliation in affiliations],
+    }
+
+    with app.test_request_context():
+        JACOWPlugin._person_link_schema_pre_load(None, PersonLinkSchema, data)
+        person_link_data = PersonLinkSchema(unknown=EXCLUDE).load(data)
+
+        assert g.jacow_affiliations_ids == {'ada@example.com': [affiliation.id for affiliation in affiliations]}
+        assert person_link_data['affiliation'] == affiliation_text
+
+
+def test_person_link_schema_post_dump_omits_core_affiliation_for_jacow_affiliations(db, app):
+    from indico.modules.events.persons.schemas import PersonLinkSchema
+
+    from indico_jacow.plugin import JACOWPlugin
+
+    affiliation = Affiliation(name='Affiliation One')
+    db.session.add(affiliation)
+    db.session.flush()
+    person_link = ContributionPersonLink()
+    person_link.jacow_affiliations = [ContributionAffiliation(affiliation=affiliation)]
+    data = [{'affiliation_id': affiliation.id, 'affiliation_meta': {'id': affiliation.id}}]
+
+    with app.test_request_context():
+        JACOWPlugin._person_link_schema_post_dump(None, PersonLinkSchema, data, [person_link])
+
+        assert 'affiliation_id' not in data[0]
+        assert 'affiliation_meta' not in data[0]
+        assert data[0]['jacow_affiliations_ids'] == [affiliation.id]
 
 
 @pytest.mark.parametrize(('reviews', 'expected'), (

--- a/indico_jacow/plugin.py
+++ b/indico_jacow/plugin.py
@@ -286,6 +286,10 @@ class JACOWPlugin(IndicoPlugin):
             return True
 
     def _person_link_schema_pre_load(self, sender, data, **kwargs):
+        if 'jacow_affiliations_ids' not in data:
+            return
+        data.pop('affiliation_id', None)
+        data.pop('affiliation_link', None)
         jacow_affiliations_ids = g.setdefault('jacow_affiliations_ids', {})
         jacow_affiliations_ids[data['email'].lower()] = data.get('jacow_affiliations_ids', [])
 
@@ -293,6 +297,9 @@ class JACOWPlugin(IndicoPlugin):
         if not all(isinstance(p, (AbstractPersonLink, ContributionPersonLink)) for p in orig):
             return
         for person, person_link in zip(data, orig, strict=True):
+            if person_link.jacow_affiliations:
+                person.pop('affiliation_id', None)
+                person.pop('affiliation_meta', None)
             person['jacow_affiliations_ids'] = [ja.affiliation.id for ja in person_link.jacow_affiliations]
             person['jacow_affiliations_meta'] = [ja.details for ja in person_link.jacow_affiliations]
 


### PR DESCRIPTION
This PR fixes a bug that when an author with multiple affiliations has an Indico profile with an affiliation link AND their contribution is edited, the affiliation text is filled with the user profile's affiliation instead of the concatenation of the multiple affiliations.